### PR TITLE
feat: add inline slug preview ghost text for docs.yml paths

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,4 @@
 .vscode/launch.json
 .gitignore
 .git/
-node_modules/
 *.vsix

--- a/extension.js
+++ b/extension.js
@@ -297,6 +297,12 @@ function updateSlugDecorations(editor) {
             return;
         }
 
+        // Only activate on Fern docs-related YAML files (must have navigation, tabs, products, or versions)
+        if (!parsed.navigation && !parsed.tabs && !parsed.products && !parsed.versions) {
+            editor.setDecorations(slugDecorationType, []);
+            return;
+        }
+
         const slugMap = computeSlugMap(parsed, document.fileName);
         const decorations = buildSlugDecorations(document, slugMap);
         editor.setDecorations(slugDecorationType, decorations);
@@ -325,11 +331,48 @@ function computeSlugMap(parsed, filePath) {
     const parentParts = productSlug ? [productSlug] : [];
 
     if (parsed.navigation) {
-        walkNavigation(parsed.navigation, parentParts, slugMap, ymlDir);
+        // Handle versioned navigation: { type: 'versioned', versions: [...] }
+        if (Array.isArray(parsed.navigation)) {
+            walkNavigation(parsed.navigation, parentParts, slugMap, ymlDir);
+        } else if (parsed.navigation.versions && Array.isArray(parsed.navigation.versions)) {
+            // Versioned navigation — each version has its own navigation tree
+            for (const version of parsed.navigation.versions) {
+                if (!version || typeof version !== 'object') continue;
+                const versionSlug = version.slug ?? kebabCase(version.version ?? '');
+                const versionParts = [...parentParts, versionSlug];
+                if (version.navigation) {
+                    if (Array.isArray(version.navigation)) {
+                        walkNavigation(version.navigation, versionParts, slugMap, ymlDir);
+                    } else if (version.navigation.items && Array.isArray(version.navigation.items)) {
+                        walkNavigation(version.navigation.items, versionParts, slugMap, ymlDir);
+                    }
+                }
+                if (version.tabs) {
+                    walkTabs(version.tabs, versionParts, slugMap, ymlDir);
+                }
+            }
+        }
     }
 
     if (parsed.tabs) {
         walkTabs(parsed.tabs, parentParts, slugMap, ymlDir);
+    }
+
+    // Handle top-level versions key (alternative versioned format)
+    if (parsed.versions && Array.isArray(parsed.versions)) {
+        for (const version of parsed.versions) {
+            if (!version || typeof version !== 'object') continue;
+            const versionSlug = version.slug ?? kebabCase(version.version ?? '');
+            const versionParts = [...parentParts, versionSlug];
+            if (version.navigation) {
+                if (Array.isArray(version.navigation)) {
+                    walkNavigation(version.navigation, versionParts, slugMap, ymlDir);
+                }
+            }
+            if (version.tabs) {
+                walkTabs(version.tabs, versionParts, slugMap, ymlDir);
+            }
+        }
     }
 
     return slugMap;
@@ -381,6 +424,17 @@ function walkNavigation(items, parentParts, slugMap, ymlDir) {
             const apiParts = [...parentParts, urlSlug];
             walkNavigation(item.layout, apiParts, slugMap, ymlDir);
         }
+
+        // Changelog: has "changelog" key (directory path(s)), contributes a slug segment
+        if (item.changelog) {
+            const title = item.title ?? 'Changelog';
+            const urlSlug = item.slug ?? kebabCase(title);
+            // Changelog doesn't have child pages in docs.yml, but registers its own slug
+            // No path to annotate here — changelog entries are auto-discovered from directory
+        }
+
+        // Link: has "link" and "href"/"url" — external URL, no slug generated
+        // (intentionally skipped — links don't produce slugs)
     }
 }
 

--- a/extension.js
+++ b/extension.js
@@ -355,7 +355,7 @@ function walkNavigation(items, parentParts, slugMap, ymlDir) {
             if (frontmatterSlug) {
                 slugMap.set(item.path, frontmatterSlug);
             } else {
-                const urlSlug = item.slug || kebabCase(item.page);
+                const urlSlug = item.slug ?? kebabCase(item.page);
                 const parts = [...parentParts, urlSlug];
                 const slug = parts.filter(Boolean).join('/');
                 slugMap.set(item.path, slug);
@@ -368,7 +368,7 @@ function walkNavigation(items, parentParts, slugMap, ymlDir) {
             if (item['skip-slug']) {
                 sectionParts = [...parentParts];
             } else {
-                const urlSlug = item.slug || kebabCase(item.section);
+                const urlSlug = item.slug ?? kebabCase(item.section);
                 sectionParts = [...parentParts, urlSlug];
             }
             walkNavigation(item.contents, sectionParts, slugMap, ymlDir);
@@ -377,7 +377,7 @@ function walkNavigation(items, parentParts, slugMap, ymlDir) {
         // API reference with layout containing pages
         if (item.api !== undefined && item.layout) {
             const apiName = typeof item.api === 'string' ? item.api : '';
-            const urlSlug = item.slug || kebabCase(apiName);
+            const urlSlug = item.slug ?? kebabCase(apiName);
             const apiParts = [...parentParts, urlSlug];
             walkNavigation(item.layout, apiParts, slugMap, ymlDir);
         }
@@ -394,7 +394,7 @@ function walkTabs(tabs, parentParts, slugMap, ymlDir) {
         if (!tab || typeof tab !== 'object') continue;
 
         if (tab.tab && (tab.layout || tab.contents)) {
-            const urlSlug = tab.slug || kebabCase(tab.tab);
+            const urlSlug = tab.slug ?? kebabCase(tab.tab);
             const tabParts = tab['skip-slug'] ? [...parentParts] : [...parentParts, urlSlug];
             const children = tab.layout || tab.contents;
             walkNavigation(children, tabParts, slugMap, ymlDir);
@@ -442,7 +442,7 @@ function getProductSlug(rootInfo, productYmlPath) {
         if (!product.path) continue;
         const resolvedPath = path.resolve(rootDir, product.path);
         if (resolvedPath === resolvedProductPath) {
-            return product.slug || null;
+            return product.slug ?? null;
         }
     }
     return null;

--- a/extension.js
+++ b/extension.js
@@ -2,6 +2,7 @@ const vscode = require('vscode');
 const path = require('path');
 const fs = require('fs');
 const yaml = require('yaml');
+const kebabCase = require('lodash.kebabcase');
 
 let linkProviderDisposable = null;
 let isLinkProviderEnabled = false;
@@ -211,22 +212,7 @@ class FilePathLinkProvider {
 // slug generation logic from the Fern platform's SlugGenerator.
 // ============================================================================
 
-/**
- * Converts a string to kebab-case, matching Fern's slug generation behavior.
- * e.g. "Getting Started" -> "getting-started"
- *      "API References" -> "api-references"
- *      "Custom CSS & JS" -> "custom-css-and-js"
- */
-function kebabCase(str) {
-    if (!str) return '';
-    return str
-        .replace(/&/g, ' and ')
-        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-        .replace(/[^a-zA-Z0-9]+/g, '-')
-        .toLowerCase()
-        .replace(/^-+|-+$/g, '')
-        .replace(/-+/g, '-');
-}
+// kebabCase is provided by lodash.kebabcase (same implementation used by Fern CLI)
 
 /**
  * Initialize slug annotation decorations and event listeners.
@@ -486,3 +472,4 @@ module.exports = {
     activate,
     deactivate
 };
+

--- a/extension.js
+++ b/extension.js
@@ -1,9 +1,14 @@
 const vscode = require('vscode');
 const path = require('path');
 const fs = require('fs');
+const yaml = require('yaml');
 
 let linkProviderDisposable = null;
 let isLinkProviderEnabled = false;
+
+// Slug annotation state
+let slugDecorationType = null;
+let slugUpdateTimeout = null;
 
 function activate(context) {
     console.log('File Path Opener extension is now active!');
@@ -59,6 +64,9 @@ function activate(context) {
     });
 
     context.subscriptions.push(disposable);
+
+    // Initialize slug annotations
+    initSlugAnnotations(context);
 }
 
 function getFilePathAtPosition(lineText, characterPos) {
@@ -135,7 +143,6 @@ function enableDocumentLinks(context) {
     
     context.subscriptions.push(linkProviderDisposable);
     isLinkProviderEnabled = true;
-    
 }
 
 function disableDocumentLinks() {
@@ -171,12 +178,10 @@ class FilePathLinkProvider {
                     const startPos = match.index + pathStartInMatch;
                     const endPos = startPos + filePath.length;
                     
-                    // Resolve the file path
                     const fullPath = resolveFilePath(filePath, document.fileName);
-                    
 
                     if (!fs.existsSync(fullPath)) {
-                        continue; // Skip if file doesn't exist
+                        continue;
                     }
                     
                     const range = new vscode.Range(
@@ -198,10 +203,286 @@ class FilePathLinkProvider {
     }
 }
 
+// ============================================================================
+// Slug Annotation Feature
+//
+// Shows ghost text next to "path:" values in docs.yml / product yml files,
+// displaying the auto-generated URL slug for each page. This mirrors the
+// slug generation logic from the Fern platform's SlugGenerator.
+// ============================================================================
+
+/**
+ * Converts a string to kebab-case, matching Fern's slug generation behavior.
+ * e.g. "Getting Started" -> "getting-started"
+ *      "API References" -> "api-references"
+ *      "Custom CSS & JS" -> "custom-css-and-js"
+ */
+function kebabCase(str) {
+    if (!str) return '';
+    return str
+        .replace(/&/g, ' and ')
+        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+        .replace(/[^a-zA-Z0-9]+/g, '-')
+        .toLowerCase()
+        .replace(/^-+|-+$/g, '')
+        .replace(/-+/g, '-');
+}
+
+/**
+ * Initialize slug annotation decorations and event listeners.
+ */
+function initSlugAnnotations(context) {
+    slugDecorationType = vscode.window.createTextEditorDecorationType({
+        after: {
+            color: new vscode.ThemeColor('editorGhostText.foreground'),
+            fontStyle: 'italic',
+            margin: '0 0 0 2em',
+        },
+        isWholeLine: false,
+    });
+
+    context.subscriptions.push(slugDecorationType);
+
+    vscode.window.onDidChangeActiveTextEditor(editor => {
+        if (editor) {
+            triggerSlugUpdate(editor);
+        }
+    }, null, context.subscriptions);
+
+    vscode.workspace.onDidChangeTextDocument(event => {
+        const editor = vscode.window.activeTextEditor;
+        if (editor && event.document === editor.document) {
+            triggerSlugUpdate(editor);
+        }
+    }, null, context.subscriptions);
+
+    if (vscode.window.activeTextEditor) {
+        triggerSlugUpdate(vscode.window.activeTextEditor);
+    }
+}
+
+/**
+ * Debounced trigger for updating slug decorations.
+ */
+function triggerSlugUpdate(editor) {
+    if (slugUpdateTimeout) {
+        clearTimeout(slugUpdateTimeout);
+    }
+    slugUpdateTimeout = setTimeout(() => updateSlugDecorations(editor), 300);
+}
+
+/**
+ * Main function to compute and display slug annotations.
+ */
+function updateSlugDecorations(editor) {
+    if (!editor || !slugDecorationType) return;
+
+    const document = editor.document;
+    const fileName = path.basename(document.fileName);
+
+    if (!fileName.endsWith('.yml') && !fileName.endsWith('.yaml')) {
+        editor.setDecorations(slugDecorationType, []);
+        return;
+    }
+
+    try {
+        const text = document.getText();
+        const parsed = yaml.parse(text);
+
+        if (!parsed) {
+            editor.setDecorations(slugDecorationType, []);
+            return;
+        }
+
+        const slugMap = computeSlugMap(parsed, document.fileName);
+        const decorations = buildSlugDecorations(document, slugMap);
+        editor.setDecorations(slugDecorationType, decorations);
+    } catch (e) {
+        // YAML parse errors are expected while editing; silently clear decorations
+        editor.setDecorations(slugDecorationType, []);
+    }
+}
+
+/**
+ * Compute a map from path string -> slug string by walking the navigation tree.
+ */
+function computeSlugMap(parsed, filePath) {
+    const slugMap = new Map();
+
+    let productSlug = '';
+
+    if (parsed.navigation || parsed.tabs) {
+        const rootInfo = findRootDocsYml(filePath);
+        if (rootInfo) {
+            productSlug = getProductSlug(rootInfo, filePath) || '';
+        }
+    }
+
+    const parentParts = productSlug ? [productSlug] : [];
+
+    if (parsed.navigation) {
+        walkNavigation(parsed.navigation, parentParts, slugMap);
+    }
+
+    if (parsed.tabs) {
+        walkTabs(parsed.tabs, parentParts, slugMap);
+    }
+
+    return slugMap;
+}
+
+/**
+ * Walk navigation items recursively, computing slugs for each page.
+ *
+ * Slug logic mirrors the Fern platform's SlugGenerator:
+ *   urlSlug = item.slug ?? kebabCase(item.title)
+ *   fullSlug = parentParts.join('/') + '/' + urlSlug
+ */
+function walkNavigation(items, parentParts, slugMap) {
+    if (!Array.isArray(items)) return;
+
+    for (const item of items) {
+        if (item === null || typeof item !== 'object') continue;
+
+        // Page: has "page" (title) and "path" (file reference)
+        if (item.page && item.path) {
+            const urlSlug = item.slug || kebabCase(item.page);
+            const parts = [...parentParts, urlSlug];
+            const slug = parts.filter(Boolean).join('/');
+            slugMap.set(item.path, slug);
+        }
+
+        // Section: has "section" (title) and "contents" (children)
+        if (item.section && item.contents) {
+            let sectionParts;
+            if (item['skip-slug']) {
+                sectionParts = [...parentParts];
+            } else {
+                const urlSlug = item.slug || kebabCase(item.section);
+                sectionParts = [...parentParts, urlSlug];
+            }
+            walkNavigation(item.contents, sectionParts, slugMap);
+        }
+
+        // API reference with layout containing pages
+        if (item.api !== undefined && item.layout) {
+            const apiName = typeof item.api === 'string' ? item.api : '';
+            const urlSlug = item.slug || kebabCase(apiName);
+            const apiParts = [...parentParts, urlSlug];
+            walkNavigation(item.layout, apiParts, slugMap);
+        }
+    }
+}
+
+/**
+ * Walk tabbed navigation structure.
+ */
+function walkTabs(tabs, parentParts, slugMap) {
+    if (!Array.isArray(tabs)) return;
+
+    for (const tab of tabs) {
+        if (!tab || typeof tab !== 'object') continue;
+
+        if (tab.tab && (tab.layout || tab.contents)) {
+            const urlSlug = tab.slug || kebabCase(tab.tab);
+            const tabParts = tab['skip-slug'] ? [...parentParts] : [...parentParts, urlSlug];
+            const children = tab.layout || tab.contents;
+            walkNavigation(children, tabParts, slugMap);
+        }
+    }
+}
+
+/**
+ * Search upward from a product yml file to find the root docs.yml
+ * that contains a "products" key referencing this file.
+ */
+function findRootDocsYml(productYmlPath) {
+    let dir = path.dirname(productYmlPath);
+
+    for (let i = 0; i < 10; i++) {
+        const candidate = path.join(dir, 'docs.yml');
+        if (fs.existsSync(candidate) && path.resolve(candidate) !== path.resolve(productYmlPath)) {
+            try {
+                const content = fs.readFileSync(candidate, 'utf8');
+                const parsed = yaml.parse(content);
+                if (parsed && parsed.products) {
+                    return { filePath: candidate, content: parsed };
+                }
+            } catch {
+                // Skip files that fail to parse
+            }
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) break;
+        dir = parent;
+    }
+    return null;
+}
+
+/**
+ * Given a root docs.yml and a product yml file path, find the product's slug.
+ */
+function getProductSlug(rootInfo, productYmlPath) {
+    if (!rootInfo || !rootInfo.content.products) return null;
+
+    const rootDir = path.dirname(rootInfo.filePath);
+    const resolvedProductPath = path.resolve(productYmlPath);
+
+    for (const product of rootInfo.content.products) {
+        if (!product.path) continue;
+        const resolvedPath = path.resolve(rootDir, product.path);
+        if (resolvedPath === resolvedProductPath) {
+            return product.slug || null;
+        }
+    }
+    return null;
+}
+
+/**
+ * Build VS Code decoration objects for each path line that has a computed slug.
+ */
+function buildSlugDecorations(document, slugMap) {
+    if (slugMap.size === 0) return [];
+
+    const decorations = [];
+    const text = document.getText();
+    const lines = text.split('\n');
+
+    const pathPattern = /^(\s*path:\s*)(.+)$/;
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const match = pathPattern.exec(line);
+        if (!match) continue;
+
+        // Strip surrounding quotes from the path value
+        const pathValue = match[2].trim().replace(/^["']|["']$/g, '');
+        const slug = slugMap.get(pathValue);
+        if (!slug) continue;
+
+        const range = new vscode.Range(
+            new vscode.Position(i, line.length),
+            new vscode.Position(i, line.length)
+        );
+
+        decorations.push({
+            range,
+            renderOptions: {
+                after: {
+                    contentText: `  slug: /${slug}`,
+                    color: new vscode.ThemeColor('editorGhostText.foreground'),
+                    fontStyle: 'italic',
+                }
+            }
+        });
+    }
+
+    return decorations;
+}
+
 function deactivate() {}
 
 module.exports = {
     activate,
     deactivate
 };
-

--- a/extension.js
+++ b/extension.js
@@ -215,6 +215,23 @@ class FilePathLinkProvider {
 // kebabCase is provided by lodash.kebabcase (same implementation used by Fern CLI)
 
 /**
+ * Read the frontmatter `slug` field from an MDX/MD file, if it exists.
+ * Returns the slug string or null if not found.
+ */
+function readFrontmatterSlug(filePath) {
+    try {
+        if (!fs.existsSync(filePath)) return null;
+        const content = fs.readFileSync(filePath, 'utf8');
+        const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+        if (!fmMatch) return null;
+        const frontmatter = yaml.parse(fmMatch[1]);
+        return (frontmatter && typeof frontmatter.slug === 'string') ? frontmatter.slug : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
  * Initialize slug annotation decorations and event listeners.
  */
 function initSlugAnnotations(context) {
@@ -294,6 +311,7 @@ function updateSlugDecorations(editor) {
  */
 function computeSlugMap(parsed, filePath) {
     const slugMap = new Map();
+    const ymlDir = path.dirname(filePath);
 
     let productSlug = '';
 
@@ -307,11 +325,11 @@ function computeSlugMap(parsed, filePath) {
     const parentParts = productSlug ? [productSlug] : [];
 
     if (parsed.navigation) {
-        walkNavigation(parsed.navigation, parentParts, slugMap);
+        walkNavigation(parsed.navigation, parentParts, slugMap, ymlDir);
     }
 
     if (parsed.tabs) {
-        walkTabs(parsed.tabs, parentParts, slugMap);
+        walkTabs(parsed.tabs, parentParts, slugMap, ymlDir);
     }
 
     return slugMap;
@@ -324,7 +342,7 @@ function computeSlugMap(parsed, filePath) {
  *   urlSlug = item.slug ?? kebabCase(item.title)
  *   fullSlug = parentParts.join('/') + '/' + urlSlug
  */
-function walkNavigation(items, parentParts, slugMap) {
+function walkNavigation(items, parentParts, slugMap, ymlDir) {
     if (!Array.isArray(items)) return;
 
     for (const item of items) {
@@ -332,10 +350,16 @@ function walkNavigation(items, parentParts, slugMap) {
 
         // Page: has "page" (title) and "path" (file reference)
         if (item.page && item.path) {
-            const urlSlug = item.slug || kebabCase(item.page);
-            const parts = [...parentParts, urlSlug];
-            const slug = parts.filter(Boolean).join('/');
-            slugMap.set(item.path, slug);
+            // Check for frontmatter slug override in the referenced MDX/MD file
+            const frontmatterSlug = ymlDir ? readFrontmatterSlug(path.resolve(ymlDir, item.path)) : null;
+            if (frontmatterSlug) {
+                slugMap.set(item.path, frontmatterSlug);
+            } else {
+                const urlSlug = item.slug || kebabCase(item.page);
+                const parts = [...parentParts, urlSlug];
+                const slug = parts.filter(Boolean).join('/');
+                slugMap.set(item.path, slug);
+            }
         }
 
         // Section: has "section" (title) and "contents" (children)
@@ -347,7 +371,7 @@ function walkNavigation(items, parentParts, slugMap) {
                 const urlSlug = item.slug || kebabCase(item.section);
                 sectionParts = [...parentParts, urlSlug];
             }
-            walkNavigation(item.contents, sectionParts, slugMap);
+            walkNavigation(item.contents, sectionParts, slugMap, ymlDir);
         }
 
         // API reference with layout containing pages
@@ -355,7 +379,7 @@ function walkNavigation(items, parentParts, slugMap) {
             const apiName = typeof item.api === 'string' ? item.api : '';
             const urlSlug = item.slug || kebabCase(apiName);
             const apiParts = [...parentParts, urlSlug];
-            walkNavigation(item.layout, apiParts, slugMap);
+            walkNavigation(item.layout, apiParts, slugMap, ymlDir);
         }
     }
 }
@@ -363,7 +387,7 @@ function walkNavigation(items, parentParts, slugMap) {
 /**
  * Walk tabbed navigation structure.
  */
-function walkTabs(tabs, parentParts, slugMap) {
+function walkTabs(tabs, parentParts, slugMap, ymlDir) {
     if (!Array.isArray(tabs)) return;
 
     for (const tab of tabs) {
@@ -373,7 +397,7 @@ function walkTabs(tabs, parentParts, slugMap) {
             const urlSlug = tab.slug || kebabCase(tab.tab);
             const tabParts = tab['skip-slug'] ? [...parentParts] : [...parentParts, urlSlug];
             const children = tab.layout || tab.contents;
-            walkNavigation(children, tabParts, slugMap);
+            walkNavigation(children, tabParts, slugMap, ymlDir);
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,44 @@
+{
+    "name": "file-path-opener",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "file-path-opener",
+            "version": "1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "yaml": "^2.8.2"
+            },
+            "devDependencies": {
+                "@types/node": "^16.x"
+            },
+            "engines": {
+                "vscode": "^1.60.0"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "16.18.126",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+            "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/yaml": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
+                "lodash.kebabcase": "^4.1.1",
                 "yaml": "^2.8.2"
             },
             "devDependencies": {
@@ -23,6 +24,12 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
             "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.kebabcase": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+            "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
             "license": "MIT"
         },
         "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,15 @@
         "type": "git",
         "url": "https://github.com/fern-api/file-path-opener.git"
     },
-    "keywords": ["file", "path", "opener", "markdown", "yaml", "mdx", "docs"],
+    "keywords": [
+        "file",
+        "path",
+        "opener",
+        "markdown",
+        "yaml",
+        "mdx",
+        "docs"
+    ],
     "engines": {
         "vscode": "^1.60.0"
     },
@@ -45,9 +53,8 @@
     },
     "devDependencies": {
         "@types/node": "^16.x"
+    },
+    "dependencies": {
+        "yaml": "^2.8.2"
     }
 }
-
-
-
-

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "@types/node": "^16.x"
     },
     "dependencies": {
+        "lodash.kebabcase": "^4.1.1",
         "yaml": "^2.8.2"
     }
 }


### PR DESCRIPTION
# feat: add inline slug preview ghost text for docs.yml paths

## Summary

Adds ghost text (inline annotations) to YAML files that shows the auto-generated URL slug next to each `path:` value in docs.yml navigation trees. Similar to how git blame extensions show inline annotations, this displays `slug: /section/page-title` in italic ghost text after each page path reference.

**How it works:**
- Parses the YAML navigation structure (`navigation`, `tabs`, sections, API references, changelog, versioned navigation)
- Computes slugs using `lodash.kebabcase` — the same `kebabCase` implementation used by the Fern CLI (`lodash-es`) and fern-platform (`es-toolkit/string`)
- Uses `??` (nullish coalescing) for slug fallback, matching Fern's `SlugGenerator` semantics exactly
- Reads MDX/MD file frontmatter to pick up `slug:` overrides — if a referenced page has a `slug` field in its frontmatter, that value is used as the full slug (matching Fern's `markdownFilesToFullSlugs` → `SlugGenerator.set()` behavior)
- Handles nested sections, `skip-slug` flag, explicit `slug:` overrides, tabbed navigation, and versioned navigation
- For product-level YAML files, walks up the directory tree to find a root `docs.yml` and resolves the product slug prefix
- Only activates on Fern docs YAML files (checks for `navigation`, `tabs`, `products`, or `versions` keys)
- Decorations update in real-time (debounced 300ms) as the document is edited

**Changes:**
- `extension.js`: Added ~350 lines of slug annotation logic (navigation walking, frontmatter reading, versioned navigation, VS Code decoration rendering)
- `package.json`: Added `yaml` and `lodash.kebabcase` runtime dependencies
- `.vscodeignore`: Removed `node_modules/` exclusion so runtime packages get bundled with the extension
- `package-lock.json`: Generated lockfile

## Updates since last revision

- Replaced custom `kebabCase` implementation with `lodash.kebabcase` for exact fidelity with Fern's slug generation. The original custom version incorrectly converted `&` to `"and"` (e.g. `"Custom CSS & JS"` → `"custom-css-and-js"`) whereas Fern/lodash treats `&` as a word separator (`"custom-css-js"`).
- Added frontmatter slug override support: the extension now resolves each `path:` to a file on disk and reads the YAML frontmatter for a `slug` field. If present, this overrides the computed slug (used as full slug, not a segment — matching Fern's `SlugGenerator.set()` via `markdownFilesToFullSlugs`).
- Fixed all slug fallback operators from `||` to `??` to match Fern's nullish coalescing semantics (so explicit `slug: ""` is respected).
- Added versioned navigation support: walks `versions` arrays (both nested under `navigation` and top-level) and prepends version slug segments.
- Added changelog and link node awareness in the navigation walker (changelog computes its slug segment; links are intentionally skipped as they don't produce slugs).
- Restricted ghost text activation to Fern docs YAML files only — the parsed YAML must contain `navigation`, `tabs`, `products`, or `versions` keys. Non-Fern YAML files will no longer be processed.

## Review & Testing Checklist for Human


- [ ] **Test with a real docs.yml**: Install the extension locally and open a Fern docs.yml file to verify ghost text appears correctly next to `path:` lines. Test both computed slugs and frontmatter slug overrides.
- [ ] **Verify versioned navigation slugs**: Test with a versioned navigation docs.yml (if available) to confirm version slug segments are prepended correctly.
- [ ] **Performance with large doc sites**: The extension reads MDX files from disk on every debounced update (every 300ms while typing). Test with a large docs site (~50+ pages) to ensure decorations don't lag noticeably.
- [ ] **Verify frontmatter slug behavior**: Confirm that frontmatter `slug` fields are used as full slugs (no parent parts prepended), matching Fern's `SlugGenerator.set()` behavior. Test a nested page with a frontmatter slug to verify.
- [ ] **Verify no regressions to existing functionality**: The file-path-opener link/click behavior should be unaffected. Toggle on/off and Alt+D should still work.

### Notes

- The slug annotations now only activate on Fern docs YAML files (those with `navigation`, `tabs`, `products`, or `versions` keys). Other YAML files are ignored.
- `findRootDocsYml` and `readFrontmatterSlug` do synchronous filesystem reads — acceptable for the debounced update cadence but could cause jank on very large doc sites.
- `readFrontmatterSlug` reads the entire MDX file to extract frontmatter. For very large MDX files this could be slow, but typically MDX pages are small enough that this is acceptable.
- Changelog nodes are recognized in the navigation walker but don't produce `path:` annotations (changelog entries are auto-discovered from directories, not listed in docs.yml).
- No automated tests exist for this extension; manual testing in VS Code/Cursor is required.

**Link to Devin Session:** https://app.devin.ai/sessions/9c3abbf16446402287743c5120ed84c7  
**Requested by:** @Ryan-Amirthan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/file-path-opener/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
